### PR TITLE
Add doComplete and call in hide()

### DIFF
--- a/bootstrap3/bootstrap-without-jquery.js
+++ b/bootstrap3/bootstrap-without-jquery.js
@@ -6,11 +6,11 @@
 
 (function() {
     'use strict';
-    
+
     /*
      * Utility functions
      */
-     
+
     // transitionend - source: https://stackoverflow.com/questions/5023514/how-do-i-normalize-css3-transition-functions-across-browsers#answer-9090128
     function transitionEndEventName() {
         var i,
@@ -31,7 +31,7 @@
         return false;
     }
     var transitionend = transitionEndEventName();
-    
+
     // Get an event's target element and the element specified by the "data-target" attribute
     function getTargets(event) {
         var targets = {};
@@ -41,7 +41,7 @@
         targets.dataTarget = (dataTarget) ? document.querySelector(dataTarget) : false;
         return targets;
     }
-    
+
     // Get the potential max height of an element
     function getMaxHeight(element) {
         // Source: http://n12v.com/css-transition-to-from-auto/
@@ -52,7 +52,7 @@
         element.offsetHeight; // force repaint
         return maxHeight;
     }
-    
+
     // Fire a specified event
     // Source: http://youmightnotneedjquery.com/
     function fireTrigger(element, eventType) {
@@ -65,7 +65,7 @@
         }
     }
 
-    
+
     /*
      * Collapse action
      * 1. Get list of all elements that are collapse triggers
@@ -74,17 +74,37 @@
      * 4. When action (collapse) is complete, change target element's class name from "collapsing" to "collapse in"
      * 5. Do the reverse, i.e. "collapse in" -> "collapsing" -> "collapse"
      */
-     
+
     // Show a target element
     function show(element, trigger) {
         element.classList.remove('collapse');
         element.classList.add('collapsing');
         trigger.classList.remove('collapsed');
         trigger.setAttribute('aria-expanded', true);
-        
+
         // Set element's height to its maximum height
         element.style.height = getMaxHeight(element);
-        
+
+        doComplete(element);
+    }
+
+    // Hide a target element
+    function hide(element, trigger) {
+        element.classList.remove('collapse');
+        element.classList.remove('in');
+        element.classList.add('collapsing');
+        trigger.classList.add('collapsed');
+        trigger.setAttribute('aria-expanded', false);
+
+        // Reset element's height
+        element.style.height = getComputedStyle(element).height;
+        element.offsetHeight; // force repaint
+        element.style.height = '0px';
+
+        doComplete(element);
+    }
+
+    function doComplete(element) {
         // Call the complete() function after the transition has finished
         if (transitionend) {
             element.addEventListener(transitionend, function() {
@@ -95,27 +115,13 @@
             complete(element);
         }
     }
-    
-    // Hide a target element
-    function hide(element, trigger) {
-        element.classList.remove('collapse');
-        element.classList.remove('in');
-        element.classList.add('collapsing');
-        trigger.classList.add('collapsed');
-        trigger.setAttribute('aria-expanded', false);
-        
-        // Reset element's height
-        element.style.height = getComputedStyle(element).height;
-        element.offsetHeight; // force repaint
-        element.style.height = '0px';
-    }
-    
+
     // Change classes once transition is complete
     function complete(element) {
         element.classList.remove('collapsing');
         element.classList.add('collapse');
         element.setAttribute('aria-expanded', false);
-        
+
         // Check whether the element is unhidden
         if (element.style.height !== '0px') {
             element.classList.add('in');
@@ -128,7 +134,7 @@
         event.preventDefault();
         var targets = getTargets(event);
         var dataTarget = targets.dataTarget;
-        
+
         // Add the "in" class name when elements are unhidden
         if (dataTarget.classList.contains('in')) {
             hide(dataTarget, targets.evTarget);
@@ -137,14 +143,14 @@
         }
         return false;
     }
-    
+
     // Get all elements that are collapse triggers and add click event listeners
     var collapsibleList = document.querySelectorAll('[data-toggle=collapse]');
     for (var i = 0, leni = collapsibleList.length; i < leni; i++) {
         collapsibleList[i].onclick = doCollapse;
     }
-    
-    
+
+
     /*
      * Alert dismiss action
      * 1. Get list of all elements that are alert dismiss buttons
@@ -152,14 +158,14 @@
      * 3. When clicked, find the target or parent element with class name "alert"
      * 4. Remove that element from the DOM
      */
-     
+
     // Start the collapse action on the chosen element
     function doDismiss(event) {
         event.preventDefault();
         // Get target element from data-target attribute
         var targets = getTargets(event);
         var target = targets.dataTarget;
-        
+
         if (!target) {
             // If data-target not specified, get parent or grandparent node with class="alert"
             var parent = targets.evTarget.parentNode;
@@ -169,10 +175,10 @@
                 target = parent.parentNode;
             }
         }
-        
+
         fireTrigger(target, 'close.bs.alert');
         target.classList.remove('in');
-        
+
         function removeElement() {
             // Remove alert from DOM
             try {
@@ -182,7 +188,7 @@
                 window.console.error('Unable to remove alert');
             }
         }
-        
+
         // Call the complete() function after the transition has finished
         if (transitionend && target.classList.contains('fade')) {
             target.addEventListener(transitionend, function() {
@@ -195,14 +201,14 @@
 
         return false;
     }
-    
-     // Get all alert dismiss buttons and add click event listeners
+
+    // Get all alert dismiss buttons and add click event listeners
     var dismissList = document.querySelectorAll('[data-dismiss=alert]');
     for (var j = 0, lenj = dismissList.length; j < lenj; j++) {
         dismissList[j].onclick = doDismiss;
     }
-    
-    
+
+
     /*
      * Dropdown action
      * 1. Get list of all elements that are dropdown triggers
@@ -210,7 +216,7 @@
      * 3. When clicked, add "open" to the target element's class names, or remove if it exists
      * 4. On blur, remove "open" from the target element's class names
      */
-     
+
     // Show a dropdown menu
     function doDropdown(event) {
         event = event || window.event;
@@ -218,20 +224,20 @@
         evTarget.parentElement.classList.toggle('open');
         return false;
     }
-    
+
     // Close a dropdown menu
     function closeDropdown(event) {
         event = event || window.event;
         var evTarget = event.currentTarget || event.srcElement;
         evTarget.parentElement.classList.remove('open');
-        
+
         // Trigger the click event on the target if it not opening another menu
         if(event.relatedTarget && event.relatedTarget.getAttribute('data-toggle') !== 'dropdown') {
             event.relatedTarget.click();
         }
         return false;
     }
-    
+
     // Set event listeners for dropdown menus
     var dropdownList = document.querySelectorAll('[data-toggle=dropdown]');
     for (var k = 0, dropdown, lenk = dropdownList.length; k < lenk; k++) {


### PR DESCRIPTION
When toggling a collapsable element, when the element is visible and `hide()` is triggered, it never calls `complete()`, therefore not cleaning up the `classList`.
